### PR TITLE
Change address of git repository for crosstool-NG in vm-bootstrap.sh script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples"]
+	path = examples
+	url = https://github.com/OLIMEX/ESP8266.git

--- a/vm-bootstrap.sh
+++ b/vm-bootstrap.sh
@@ -16,7 +16,7 @@ sudo chown vagrant /opt/Espressif
 # Build the cross-compiler
 cd /opt/Espressif
 if [ ! -d /opt/Espressif/crosstool-NG ]; then
-  git clone -b lx106 git://github.com/jcmvbkbc/crosstool-NG.git
+  git clone -b lx106 https://github.com/jcmvbkbc/crosstool-NG.git
 fi
 
 cd /opt/Espressif/crosstool-NG


### PR DESCRIPTION
Changed from   git://github.com/jcmvbkbc/crosstool-NG.git
         to  https://github.com/jcmvbkbc/crosstool-NG.git

https:// is correct address for cloning on github pages.
git:// does not work in my case and I think I won't be alone
